### PR TITLE
only log if DEBUG_PKCS11 is set

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,13 +13,47 @@ clean:
 package main
 
 import (
+	"log"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+
 	"github.com/namecoin/pkcs11mod"
 )
 
 func init() {
 	backend := NewBackendNamecoin()
-
+	if os.Getenv("DEBUG_PKCS11") != "" {
+		// open log file
+		mode := os.O_CREATE | os.O_APPEND | os.O_WRONLY
+		f, err := os.OpenFile(filepath.Join(getBasedir(), "pkcs11mod.log"), mode, 0600)
+		if err != nil {
+			println("error opening debug log file:", err.Error())
+			f = os.Stderr
+		}
+		pkcs11mod.SetLogOutput(f)
+	}
 	pkcs11mod.SetBackend(backend)
+	log.Println("Namecoin PKCS#11 module loading")
+}
+
+func getBasedir() string {
+	if appdata := os.Getenv("LOCALAPPDATA"); runtime.GOOS == "windows" && appdata != "" {
+		return filepath.Join(appdata, "Namecoin")
+	}
+	usr, err := user.Current()
+	if err != nil {
+		return filepath.Join(os.Getenv("HOME"), ".namecoin")
+	}
+	switch runtime.GOOS {
+	case "windows":
+		return filepath.Join(usr.HomeDir, "AppData", "Roaming", "Namecoin")
+	case "darwin":
+		return filepath.Join(usr.HomeDir, "Library", "Namecoin")
+	default:
+		return filepath.Join(usr.HomeDir, ".namecoin")
+	}
 }
 
 func main() {}


### PR DESCRIPTION
this moves the debug log file (if DEBUG_PKCS11 is set) into the ~/.namecoin/ directory or, on windows or osx equivalent

if this isn't a good log path, open to changing to somewhere else, but I think its nicer than $HOME or $PWD