### PR TITLE
Trace the number of returned certs

### DIFF
--- a/backend_namecoin_positive.go
+++ b/backend_namecoin_positive.go
@@ -223,5 +223,9 @@ func (b *BackendNamecoinPositive) queryCommonName(name string) ([]*p11trustmod.C
 		results = append(results, certData)
 	}
 
+	if b.trace && b.traceSensitive {
+		log.Printf("ncp11: Returned %d certificates for: %s\n", len(results), name)
+	}
+
 	return results, nil
 }


### PR DESCRIPTION
Should make it easier to debug a cert rejection in Firefox on Windows.